### PR TITLE
Do not reference the deprecated use plugin in AMD registration

### DIFF
--- a/intelligenttext.js
+++ b/intelligenttext.js
@@ -10,7 +10,7 @@
 (function (root, factory) {
     if (typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
-        define(['use!underscore', 'jquery'], function (_, jQuery) {
+        define(['underscore', 'jquery'], function (_, jQuery) {
             return factory(_, jQuery);
         });
     } else {


### PR DESCRIPTION
use! has been deprecated, r.js now supports shims to do dependency management of non-AMD modules.
